### PR TITLE
Add 100px padding to Code of Conduct page

### DIFF
--- a/_sass/pages/_code-of-conduct.scss
+++ b/_sass/pages/_code-of-conduct.scss
@@ -1,0 +1,3 @@
+.code-of-conduct {
+  padding-bottom: 100px;
+}

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -6,7 +6,7 @@ order: 3
 ---
 
 <!-- Main -->
-<div id="main">
+<div id="main" class="code-of-conduct">
     <div class="container">
 
         <!-- Content -->

--- a/css/site.scss
+++ b/css/site.scss
@@ -198,3 +198,4 @@ footer {
 }
 
 @import 'pages/sponsors';
+@import 'pages/code-of-conduct';


### PR DESCRIPTION
The footer has a 50px padding-top which is covering the content at the end of the Code of Conduct
